### PR TITLE
feat: 팀원간 코드스타일 통일을 위해 .editorconfig를 추가했습니다.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 80
+
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION

charset 
*  utf-8  파일 인코딩은 UTF-8로  다른 인코딩(CP949, EUC-KR 등) 사용 불가

indent_style 
* space  들여쓰기 방식은 공백으로  탭(tab) 사용 시 자동으로 스페이스(공백)로 변환

indent_size
* 4  들여쓰기 할 때 공백의 개수 4  들여쓰기 폭이 4로 고정됨

end_of_line
*  lf  줄바꿈 설정, 유닉스(LF) 사용  Windows(CRLF) 줄바꿈은 금지됨

trim_trailing_whitespace
* true  줄 끝 공백 제거  코드 작성 시 줄 마지막에 스페이스 두면 자동 삭제 됨

insert_final_newline
* true 파일 마지막에 빈 줄 추가  마지막에 빈 줄이 없으면 자동으로 추가됨

max_line_length 
* 100  한 줄의 최대 길이 80자  이보다 길어지면 IDE에서 경고(또는 자동 줄바꿈 설정 시 분할)

[*.md] trim_trailing_whitespace 
* false  md 파일은 줄 끝 공백 유지  마크다운 파일에서만 줄 끝 공백 자동 삭제하지 않음


</body></html>