### PR TITLE
feat:회원정보를 저장하기 위해 회원가입 저장기능을 만들었습니다.

### DIFF
--- a/sql/ddl.sql
+++ b/sql/ddl.sql
@@ -1,0 +1,9 @@
+CREATE TABLE member (
+         id BIGINT PRIMARY KEY AUTO_INCREMENT,
+         userid VARCHAR(50) UNIQUE NOT NULL,
+         password VARCHAR(255) NOT NULL,
+          name VARCHAR(100),
+          email VARCHAR(255),
+          tel VARCHAR(20),
+          joindate TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/src/main/java/io/cavia/mockinvest/config/SpringConfig.java
+++ b/src/main/java/io/cavia/mockinvest/config/SpringConfig.java
@@ -1,7 +1,25 @@
 package io.cavia.mockinvest.config;
 
+import io.cavia.mockinvest.repository.JpaMemberRepository;
+import io.cavia.mockinvest.repository.MemberRepository;
+import io.cavia.mockinvest.scrvice.MemberService;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SpringConfig {
+
+    private final EntityManager em;
+    public SpringConfig(EntityManager em) {
+        this.em = em;
+    }
+    @Bean
+    public MemberService memberService(MemberRepository memberRepository){
+        return new MemberService(memberRepository);
+    }
+    @Bean
+    public MemberRepository memberRepository(){
+        return new JpaMemberRepository(em);
+    }
 }

--- a/src/main/java/io/cavia/mockinvest/controller/MemberController.java
+++ b/src/main/java/io/cavia/mockinvest/controller/MemberController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.Mapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 
+import java.util.List;
+
 @Controller
 public class MemberController {
 
@@ -22,11 +24,12 @@ public class MemberController {
 
     /**
      * get방식으로 사용자에게 회원 가입 페이지를 보여줍니다.
+     *
      * @param model
      * @return
      */
     @GetMapping("/members/join")
-    public String memberJoinForm(Model model){
+    public String memberJoinForm(Model model) {
         model.addAttribute("form", new MemberForm());
         return "members/memberJoinForm";
     }
@@ -34,12 +37,13 @@ public class MemberController {
     /**
      * post방식으로 - 사용자가 가입 폼을 제출하면 회원 정보를 받아서 저장하고,
      * 중복 아이디가 있으면 오류를 반환
+     *
      * @param form
      * @param model
      * @return
      */
     @PostMapping("/members/join")
-    public String memberJoin(@ModelAttribute MemberForm form, Model model){
+    public String memberJoin(@ModelAttribute MemberForm form, Model model) {
         Member member = new Member();
         member.setUserid(form.getUserid());
         member.setName(form.getName());
@@ -49,7 +53,7 @@ public class MemberController {
         try {
             memberService.join(member);
             return "redirect:/";
-        }catch (IllegalStateException i){
+        } catch (IllegalStateException i) {
             model.addAttribute("form", form); // 기존 입력값 유지
             model.addAttribute("password", ""); // 비밀번호만 공백으로 설정
             model.addAttribute("error", "이미 존재하는 회원입니다."); // 에러 메시지 추가
@@ -57,4 +61,10 @@ public class MemberController {
         }
     }
 
+    @GetMapping("/members/list")
+    public String list(Model model) {
+        List<Member> list = memberService.findMembers();
+        model.addAttribute("members", list);
+        return "members/memberList";
+    }
 }

--- a/src/main/java/io/cavia/mockinvest/controller/MemberController.java
+++ b/src/main/java/io/cavia/mockinvest/controller/MemberController.java
@@ -1,0 +1,60 @@
+package io.cavia.mockinvest.controller;
+
+import io.cavia.mockinvest.domain.Member;
+import io.cavia.mockinvest.scrvice.MemberService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.Mapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Controller
+public class MemberController {
+
+    private MemberService memberService;
+
+    @Autowired
+    public MemberController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    /**
+     * get방식으로 사용자에게 회원 가입 페이지를 보여줍니다.
+     * @param model
+     * @return
+     */
+    @GetMapping("/members/join")
+    public String memberJoinForm(Model model){
+        model.addAttribute("form", new MemberForm());
+        return "members/memberJoinForm";
+    }
+
+    /**
+     * post방식으로 - 사용자가 가입 폼을 제출하면 회원 정보를 받아서 저장하고,
+     * 중복 아이디가 있으면 오류를 반환
+     * @param form
+     * @param model
+     * @return
+     */
+    @PostMapping("/members/join")
+    public String memberJoin(@ModelAttribute MemberForm form, Model model){
+        Member member = new Member();
+        member.setUserid(form.getUserid());
+        member.setName(form.getName());
+        member.setPassword(form.getPassword());
+        member.setTel(form.getTel());
+        member.setEmail(form.getEmail());
+        try {
+            memberService.join(member);
+            return "redirect:/";
+        }catch (IllegalStateException i){
+            model.addAttribute("form", form); // 기존 입력값 유지
+            model.addAttribute("password", ""); // 비밀번호만 공백으로 설정
+            model.addAttribute("error", "이미 존재하는 회원입니다."); // 에러 메시지 추가
+            return "members/memberJoinForm";
+        }
+    }
+
+}

--- a/src/main/java/io/cavia/mockinvest/controller/MemberForm.java
+++ b/src/main/java/io/cavia/mockinvest/controller/MemberForm.java
@@ -1,0 +1,49 @@
+package io.cavia.mockinvest.controller;
+
+public class MemberForm {
+    private String userid;
+    private String password ;
+    private String name;
+    private String email;
+    private String tel;
+
+    public String getUserid() {
+        return userid;
+    }
+
+    public void setUserid(String userid) {
+        this.userid = userid;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getTel() {
+        return tel;
+    }
+
+    public void setTel(String tel) {
+        this.tel = tel;
+    }
+}

--- a/src/main/java/io/cavia/mockinvest/domain/Member.java
+++ b/src/main/java/io/cavia/mockinvest/domain/Member.java
@@ -6,16 +6,17 @@ import java.time.LocalDateTime;
 
 @Entity
 public class Member {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
-    @Column(unique = true,nullable = false)
+    @Column(unique = true, nullable = false)
     private String userid;
     @Column(nullable = false)
     private String password;
     private String name;
     private String email;
     private String tel;
-    @Column(updatable = false,insertable = false)
+    @Column(updatable = false, insertable = false)
     private LocalDateTime joindate;
 
     public long getId() {

--- a/src/main/java/io/cavia/mockinvest/domain/Member.java
+++ b/src/main/java/io/cavia/mockinvest/domain/Member.java
@@ -1,0 +1,76 @@
+package io.cavia.mockinvest.domain;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+public class Member {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    @Column(unique = true,nullable = false)
+    private String userid;
+    @Column(nullable = false)
+    private String password;
+    private String name;
+    private String email;
+    private String tel;
+    @Column(updatable = false,insertable = false)
+    private LocalDateTime joindate;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getUserid() {
+        return userid;
+    }
+
+    public void setUserid(String userid) {
+        this.userid = userid;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getTel() {
+        return tel;
+    }
+
+    public void setTel(String tel) {
+        this.tel = tel;
+    }
+
+    public LocalDateTime getJoindate() {
+        return joindate;
+    }
+
+    public void setJoindate(LocalDateTime joindate) {
+        this.joindate = joindate;
+    }
+}

--- a/src/main/java/io/cavia/mockinvest/repository/JpaMemberRepository.java
+++ b/src/main/java/io/cavia/mockinvest/repository/JpaMemberRepository.java
@@ -1,0 +1,36 @@
+package io.cavia.mockinvest.repository;
+
+import io.cavia.mockinvest.domain.Member;
+import jakarta.persistence.EntityManager;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
+public class JpaMemberRepository implements MemberRepository{
+
+    private final EntityManager em;
+
+    public JpaMemberRepository(EntityManager em) {
+        this.em = em;
+    }
+
+    /**
+     * 회원가입한 사용자 정보 저장
+     */
+    @Override
+    public Member save(Member member) {
+        em.persist(member);
+        return member;
+    }
+
+    /**
+     *  회원 아이디 찾는 메소드
+     */
+    @Override
+    public Optional<String> findByUserid(String userid) {
+        return em.createQuery("SELECT m.userid FROM Member m WHERE m.userid = :userid", String.class)
+            .setParameter("userid",userid)
+            .getResultStream()
+            .findFirst();
+    }
+}

--- a/src/main/java/io/cavia/mockinvest/repository/JpaMemberRepository.java
+++ b/src/main/java/io/cavia/mockinvest/repository/JpaMemberRepository.java
@@ -4,9 +4,10 @@ import io.cavia.mockinvest.domain.Member;
 import jakarta.persistence.EntityManager;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.List;
 import java.util.Optional;
 
-public class JpaMemberRepository implements MemberRepository{
+public class JpaMemberRepository implements MemberRepository {
 
     private final EntityManager em;
 
@@ -24,13 +25,23 @@ public class JpaMemberRepository implements MemberRepository{
     }
 
     /**
-     *  회원 아이디 찾는 메소드
+     * 회원 아이디 찾는 메소드
      */
     @Override
     public Optional<String> findByUserid(String userid) {
         return em.createQuery("SELECT m.userid FROM Member m WHERE m.userid = :userid", String.class)
-            .setParameter("userid",userid)
-            .getResultStream()
-            .findFirst();
+                .setParameter("userid", userid)
+                .getResultStream()
+                .findFirst();
+    }
+
+    /**
+     * 모든 회원들 찾는 메소드
+     *
+     * @return
+     */
+    @Override
+    public List<Member> findAll() {
+        return em.createQuery("SELECT m  FROM Member m", Member.class).getResultList();
     }
 }

--- a/src/main/java/io/cavia/mockinvest/repository/MemberRepository.java
+++ b/src/main/java/io/cavia/mockinvest/repository/MemberRepository.java
@@ -1,0 +1,11 @@
+package io.cavia.mockinvest.repository;
+
+
+import io.cavia.mockinvest.domain.Member;
+
+import java.util.Optional;
+
+public interface MemberRepository {
+    Member save(Member member);
+    Optional<String> findByUserid(String userid);
+}

--- a/src/main/java/io/cavia/mockinvest/repository/MemberRepository.java
+++ b/src/main/java/io/cavia/mockinvest/repository/MemberRepository.java
@@ -3,9 +3,13 @@ package io.cavia.mockinvest.repository;
 
 import io.cavia.mockinvest.domain.Member;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository {
     Member save(Member member);
+
     Optional<String> findByUserid(String userid);
+
+    List<Member> findAll();
 }

--- a/src/main/java/io/cavia/mockinvest/scrvice/MemberService.java
+++ b/src/main/java/io/cavia/mockinvest/scrvice/MemberService.java
@@ -1,0 +1,37 @@
+package io.cavia.mockinvest.scrvice;
+
+import io.cavia.mockinvest.domain.Member;
+import io.cavia.mockinvest.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+
+@Transactional
+public class MemberService {
+
+    private MemberRepository memberRepository;
+
+    public MemberService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    /**
+     * 회원의 값을 받으면 중복검사 후 id값을 반환
+     * @param member
+     * @return
+     */
+    public long join(Member member){
+        if(isDuplicateUserid(member)){
+            throw new IllegalStateException("이미 존재하는 회원입니다.");
+        }
+        memberRepository.save(member);
+        return member.getId();
+    }
+
+    /**
+     * 중복된 회원의 userid가 있으면 true 없으면 false를 반환
+     * @param member
+     * @return
+     */
+    public boolean isDuplicateUserid(Member member) {
+        return memberRepository.findByUserid(member.getUserid()).isPresent();
+    }
+}

--- a/src/main/java/io/cavia/mockinvest/scrvice/MemberService.java
+++ b/src/main/java/io/cavia/mockinvest/scrvice/MemberService.java
@@ -4,6 +4,8 @@ import io.cavia.mockinvest.domain.Member;
 import io.cavia.mockinvest.repository.MemberRepository;
 import jakarta.transaction.Transactional;
 
+import java.util.List;
+
 @Transactional
 public class MemberService {
 
@@ -15,11 +17,12 @@ public class MemberService {
 
     /**
      * 회원의 값을 받으면 중복검사 후 id값을 반환
+     *
      * @param member
      * @return
      */
-    public long join(Member member){
-        if(isDuplicateUserid(member)){
+    public long join(Member member) {
+        if (isDuplicateUserid(member)) {
             throw new IllegalStateException("이미 존재하는 회원입니다.");
         }
         memberRepository.save(member);
@@ -28,10 +31,15 @@ public class MemberService {
 
     /**
      * 중복된 회원의 userid가 있으면 true 없으면 false를 반환
+     *
      * @param member
      * @return
      */
     public boolean isDuplicateUserid(Member member) {
         return memberRepository.findByUserid(member.getUserid()).isPresent();
+    }
+
+    public List<Member> findMembers() {
+        return memberRepository.findAll();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,10 @@
 spring.application.name=mock-invest
 server.port=8081
-
+spring.datasource.url=jdbc:mysql://localhost:3306/member
+spring.datasource.username=
+spring.datasource.password=
+spring.jpa.show-sql=true
+spring.jpa.hibernate.ddl-auto=update
 # stock-api-keys
 stock-api.appkey=
 stock-api.appsecret=

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -5,6 +5,15 @@
   <title>$Title$</title>
 </head>
 <body>
-$END$
+<div class="container">
+    <div>
+        <h1>Hello Spring</h1>
+        <p>회원 기능</p>
+        <p>
+            <a href="/members/join">회원 가입</a>
+            <a href="/members">회원 목록</a>
+        </p>
+    </div>
+</div>
 </body>
 </html>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -11,7 +11,7 @@
         <p>회원 기능</p>
         <p>
             <a href="/members/join">회원 가입</a>
-            <a href="/members">회원 목록</a>
+            <a href="/members/list">회원 목록</a>
         </p>
     </div>
 </div>

--- a/src/main/resources/templates/members/memberJoinForm.html
+++ b/src/main/resources/templates/members/memberJoinForm.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<div class="container">
+    <form action="/members/join" method="post">
+        <div class="form-group">
+            <label for="name">아이디</label>
+            <input type="text" id="userid" name="userid" th:value="${form.userid}" required>
+            <label for="name">비밀번호</label>
+            <input type="password" id="password" name="password" th:value="${''}" required>
+            <label for="name">이름</label>
+            <input type="text" id="name" name="name" th:value="${form.name}" required>
+            <label for="name">이메일</label>
+            <input type="text" id="email" name="email" th:value="${form.email}" required>
+            <label for="name">전화번호</label>
+            <input type="text" id="tel" name="tel" th:value="${form.tel}">
+        </div>
+        <button type="submit">등록</button>
+    </form>
+    <span th:if="${error}" th:text="${error}" style="color: red;"></span>
+</div> <!-- /container -->
+</body>
+</html>


### PR DESCRIPTION
 회원가입 정보를 저장하는 기능을 구현했습니다.
- 계층 구조는 다음과 같이 구성했습니다.
    - **controller**: MemberController, MemberForm
    - **service**: MemberService
    - **repository**: MemberRepository, JpaMemberRepository
    - **domain**: (회원 엔티티 등)
- Controller에서 GET 방식으로 요청이 들어오면 회원가입 페이지로 이동하고,  
  POST 방식으로 요청이 들어오면 회원 정보를 저장합니다.
- 중복 아이디가 있을 경우 저장이 되지 않도록 예외 처리를 했습니다.
- 폼 객체(MemberForm)는 controller 패키지 내에 별도 클래스로 두었고, 이를 통해 사용자 입력값을 받습니다.
- spring.datasource.username 는 root
spring.datasource.password 는 1234로 했습니다