### PR TITLE
Feature/10 search stock info

### DIFF
--- a/src/main/java/io/cavia/mockinvest/client/ApiOAuthManager.java
+++ b/src/main/java/io/cavia/mockinvest/client/ApiOAuthManager.java
@@ -1,0 +1,141 @@
+package io.cavia.mockinvest.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+public class ApiOAuthManager {
+    private final WebClient webClient;
+    private String accessToken;
+    private LocalDateTime tokenCreatedAt;
+    private String approvalKey;
+    private LocalDateTime keyCreatedAt;
+
+    @Value("${stock-api.appkey}")
+    private String appKey;
+
+    @Value("${stock-api.appsecret}")
+    private String appSecret;
+
+    public ApiOAuthManager(WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder
+            .baseUrl("https://openapi.koreainvestment.com:9443")
+            .build();
+    }
+
+
+    /**
+     * API 요청을 위한 액세스 토큰을 받아옴. 액세스 토큰은 싱글톤 방식으로 관리됨.
+     * 액세스 토큰을 요청한지 6시간이 지났으면, 액세스 토큰을 외부 API에 새롭게 요청해 발급받음.
+     *
+     * @return API 액세스 토큰
+     */
+    public String getAccessToken() {
+        if (accessToken == null || LocalDateTime.now().isAfter(tokenCreatedAt.plusHours(6))) {
+            System.out.println("토큰이 없거나 발급한지 6시간이 경과함, 새로운 토큰 요청");
+            requestAccessToken();
+        }
+        System.out.println(tokenCreatedAt + " 에 생성된 토큰 반환 : " + accessToken.substring(0, 10) + "...");
+        return accessToken;
+    }
+
+    private void requestAccessToken() {
+        System.out.println("Requesting new token");
+
+        try {
+            JsonNode responseNode = this.webClient.post().uri("/oauth2/tokenP")
+                .bodyValue(Map.of("grant_type", "client_credentials",
+                    "appkey", appKey,
+                    "appsecret", appSecret))
+                .retrieve() //
+                // 요청 보내고, 성공하면 응답 바디를 가져올 준비를 하고, 실패하면 예외를 던짐
+                .bodyToMono(JsonNode.class) // 응답을 JsonNode 객체로 변환
+                .block();
+
+            if (responseNode != null && responseNode.has("access_token")) {
+                String newAccessToken = responseNode.get("access_token").asText(); // 타입 안전하게
+                // 텍스트로 가져옴
+                this.accessToken = newAccessToken;
+                this.tokenCreatedAt = LocalDateTime.now();
+                System.out.println(tokenCreatedAt + " 에 새로운 토큰 발급 : " + newAccessToken);
+
+            } else {
+                throw new RuntimeException("Failed to refresh API token or access_token not found in response");
+            }
+        } catch (WebClientResponseException e) {
+            System.out.println("API 호출 중 에러 발생!");
+            System.out.println("Status Code: " + e.getStatusCode());
+            String errorBody = e.getResponseBodyAsString();
+            System.out.println("Error Body: " + errorBody);
+            throw new RuntimeException("API 호출 실패: " + errorBody, e);
+        } catch (Exception e) {
+            throw new RuntimeException("Error during token refresh: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 웹소켓 접근키 수명은 24시간임, 발급 요청 할 때마다 새로운 키가 발급됨.
+     * 한 번 연결하면 세션이 종료되기 전까지는 365일 내내 유지됨.
+     * 세션이 종료되었을 때만 요청하면 될 것으로 보임. 현재는 발급받은지 24시간이 지나면 새로 발급받음.
+     *
+     * @return API 웹소켓 접근을 위한 key
+     */
+    public String getApprovalKey() {
+        if (approvalKey == null || LocalDateTime.now().isAfter(keyCreatedAt.plusHours(24))) {
+            System.out.println("접근키가 없거나 발급한지 24시간이 경과함, 새로운 접근키 요청");
+            requestApprovalKey();
+        }
+        System.out.println(keyCreatedAt + " 에 생성된 접근키 반환 : " + approvalKey.substring(0, 10) + "...");
+        return approvalKey;
+    }
+
+    private void requestApprovalKey() {
+        System.out.println("Requesting new key");
+
+        try {
+            // 키 하나만 가지고 오면 되기 때문에 DTO 객체 대신 JsonNode 객체를 사용
+            JsonNode responseNode = this.webClient.post()
+                .uri("/oauth2" + "/Approval")
+                .bodyValue(Map.of("grant_type", "client_credentials",
+                    "appkey", appKey,
+                    "secretkey", appSecret))
+                .retrieve() // 요청 보내고,
+                // 성공하면 응답 바디를 가져올 준비를 하고 실패하면 예외를 던짐
+                .bodyToMono(JsonNode.class) // 응답을 JsonNode 객체로 변환
+                .block();
+
+            if (responseNode != null && responseNode.has("approval_key")) {
+                String newAccessToken = responseNode.get("approval_key").asText(); // 타입 안전하게
+                // 텍스트로 가져옴
+                this.approvalKey = newAccessToken;
+                this.keyCreatedAt = LocalDateTime.now();
+                System.out.println(keyCreatedAt + " 에 새로운 접근키 발급 : " + newAccessToken);
+
+            } else {
+                throw new RuntimeException("Failed to refresh API key or approval_key not found in response");
+            }
+        } catch (WebClientResponseException e) {
+            System.out.println("API 호출 중 에러 발생!");
+            System.out.println("Status Code: " + e.getStatusCode());
+            String errorBody = e.getResponseBodyAsString();
+            System.out.println("Error Body: " + errorBody);
+            throw new RuntimeException("API 호출 실패: " + errorBody, e);
+        } catch (Exception e) {
+            throw new RuntimeException("Error during key refresh: " + e.getMessage(), e);
+        }
+    }
+
+    public String getAppSecret() {
+        return appSecret;
+    }
+
+    public String getAppKey() {
+        return appKey;
+    }
+
+
+}

--- a/src/main/java/io/cavia/mockinvest/client/ApiOAuthManager.java
+++ b/src/main/java/io/cavia/mockinvest/client/ApiOAuthManager.java
@@ -10,8 +10,12 @@ import java.util.Map;
 
 public class ApiOAuthManager {
     private final WebClient webClient;
+
+    // TODO : 릴리즈 전에 제거해야함. 너무 많은 토큰 발급을 막기 위해 프로퍼티에 토큰을 써놓음
+    @Value("${stock-api.access-token}")
     private String accessToken;
-    private LocalDateTime tokenCreatedAt;
+    // TODO : 마찬가지로 임시로 현재시간으로 생성
+    private LocalDateTime tokenCreatedAt = LocalDateTime.now();
     private String approvalKey;
     private LocalDateTime keyCreatedAt;
 
@@ -21,10 +25,8 @@ public class ApiOAuthManager {
     @Value("${stock-api.appsecret}")
     private String appSecret;
 
-    public ApiOAuthManager(WebClient.Builder webClientBuilder) {
-        this.webClient = webClientBuilder
-            .baseUrl("https://openapi.koreainvestment.com:9443")
-            .build();
+    public ApiOAuthManager(WebClient webClient) {
+        this.webClient = webClient;
     }
 
 

--- a/src/main/java/io/cavia/mockinvest/client/RestWebClient.java
+++ b/src/main/java/io/cavia/mockinvest/client/RestWebClient.java
@@ -1,0 +1,55 @@
+package io.cavia.mockinvest.client;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+public class RestWebClient {
+
+    private final WebClient webClient;
+    private final ApiOAuthManager apiOAuthManager;
+
+    public RestWebClient(WebClient webClient, ApiOAuthManager apiOAuthManager) {
+        this.webClient = webClient;
+        this.apiOAuthManager = apiOAuthManager;
+    }
+
+    /**
+     * 해당하는 주식 고유 번호의 주식기본정보를 Api로부터 가져와 문자열로 반환
+     * <a href="https://apiportal.koreainvestment.com/apiservice-apiservice?/uapi/domestic-stock/v1/quotations/search-stock-info">주식기본조회[v1_국내주식-067]</a>
+     * REST API URL : /uapi/domestic-stock/v1/quotations/search-stock-info
+     *
+     * @param pdno 주식고유번호
+     * @return Api 응답 Json 문자열
+     */
+    public String searchStockInfo(String pdno) {
+
+        try {
+            String accessToken = apiOAuthManager.getAccessToken();
+            String responseBody = webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                    .path("/uapi/domestic-stock/v1/quotations/search-stock-info")
+                    .queryParam("PRDT_TYPE_CD", "300")
+                    .queryParam("PDNO", pdno)
+                    .build())
+                .header(HttpHeaders.CONTENT_TYPE, "application/json; charset=utf-8") // GET 요청시는 이렇게
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .header("appkey", apiOAuthManager.getAppKey())
+                .header("appsecret", apiOAuthManager.getAppSecret())
+                .header("tr_id", "CTPF1002R")
+                .header("custtype", "P")
+                .retrieve() // 요청 보내고, 성공하면 응답 바디를 가져올 준비를 하고, 실패하면 예외를 던짐
+                .bodyToMono(String.class)
+                .block();
+            return responseBody;
+        } catch (WebClientResponseException e) {
+            System.out.println("API 호출 중 에러 발생!");
+            System.out.println("Status Code: " + e.getStatusCode());
+            String errorBody = e.getResponseBodyAsString();
+            throw new RuntimeException("API 호출 실패: " + errorBody, e);
+        } catch (Exception e) {
+            throw new RuntimeException("메서드 실행중 예외 발생: " + e.getMessage(), e);
+        }
+    }
+
+}

--- a/src/main/java/io/cavia/mockinvest/config/SpringConfig.java
+++ b/src/main/java/io/cavia/mockinvest/config/SpringConfig.java
@@ -1,7 +1,21 @@
 package io.cavia.mockinvest.config;
 
+import io.cavia.mockinvest.client.ApiOAuthManager;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 public class SpringConfig {
+
+    private final WebClient.Builder webClientBuilder;
+
+    public SpringConfig(WebClient.Builder webClientBuilder) {
+        this.webClientBuilder = webClientBuilder;
+    }
+
+    @Bean
+    public ApiOAuthManager apiOAuthManager() {
+        return new ApiOAuthManager(webClientBuilder);
+    }
 }

--- a/src/main/java/io/cavia/mockinvest/config/SpringConfig.java
+++ b/src/main/java/io/cavia/mockinvest/config/SpringConfig.java
@@ -1,6 +1,7 @@
 package io.cavia.mockinvest.config;
 
 import io.cavia.mockinvest.client.ApiOAuthManager;
+import io.cavia.mockinvest.client.RestWebClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -15,7 +16,19 @@ public class SpringConfig {
     }
 
     @Bean
+    public WebClient webClient() {
+        return webClientBuilder
+                .baseUrl("https://openapi.koreainvestment.com:9443")
+                .build();
+    }
+
+    @Bean
+    public RestWebClient restWebClient() {
+        return new RestWebClient(webClient(), apiOAuthManager());
+    }
+
+    @Bean
     public ApiOAuthManager apiOAuthManager() {
-        return new ApiOAuthManager(webClientBuilder);
+        return new ApiOAuthManager(webClient());
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,4 @@ server.port=8081
 # stock-api-keys
 stock-api.appkey=
 stock-api.appsecret=
+stock-api.access-token=

--- a/src/test/java/io/cavia/mockinvest/client/ApiOAuthManagerTest.java
+++ b/src/test/java/io/cavia/mockinvest/client/ApiOAuthManagerTest.java
@@ -1,0 +1,22 @@
+package io.cavia.mockinvest.client;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class ApiOAuthManagerTest {
+
+    @Autowired
+    ApiOAuthManager apiOAuthManager;
+
+    @Test
+    void getToken() {
+        System.out.println(apiOAuthManager.getAccessToken());
+    }
+
+    @Test
+    void getKey(){
+        System.out.println(apiOAuthManager.getApprovalKey());
+    }
+}

--- a/src/test/java/io/cavia/mockinvest/client/IntegrationClientTest.java
+++ b/src/test/java/io/cavia/mockinvest/client/IntegrationClientTest.java
@@ -5,10 +5,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-public class ApiOAuthManagerTest {
+public class IntegrationClientTest {
 
     @Autowired
     ApiOAuthManager apiOAuthManager;
+    @Autowired
+    RestWebClient restWebClient;
 
     @Test
     void getToken() {
@@ -18,5 +20,10 @@ public class ApiOAuthManagerTest {
     @Test
     void getKey(){
         System.out.println(apiOAuthManager.getApprovalKey());
+    }
+
+    @Test
+    void searchStockInfo(){
+        System.out.println(restWebClient.searchStockInfo("005930"));//삼성전자
     }
 }


### PR DESCRIPTION
1. 액세스토큰 발급, 접근 키 발급 기능 추가, 토큰이 없으면 원래 자동으로 발급되지만 테스트를 위해 프로퍼티에 수동추가 해주어야함

2. 주식기본조회를 위한 메서드 추가 RestWebClient.searchStockInfo(String 주식고유코드)
 - 타겟 API 주식기본조회 [v1_국내주식-067], https://apiportal.koreainvestment.com/apiservice-apiservice?/uapi/domestic-stock/v1/quotations/search-stock-info
 
3. 클라이언트 통합 테스트 추가

프로퍼티에 stock-api.access-token= 
수동으로 발급받아 추가해주어야 함.
테스트를 위해 너무 많은 토큰 발급, 실전투자 토큰이기 때문에 제한 염려되어 수정함. 