### PR TITLE
chore: db는 cavia_invest_db이름으로 없으면 db 생성 및 Entity는 자동생성

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,10 +1,11 @@
 spring.application.name=mock-invest
 server.port=8081
-spring.datasource.url=jdbc:mysql://localhost:3306/member
+spring.datasource.url=jdbc:mysql://localhost:3306/cavia_invest_db?createDatabaseIfNotExist=true
 spring.datasource.username=
 spring.datasource.password=
-spring.jpa.show-sql=true
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
 # stock-api-keys
 stock-api.appkey=
 stock-api.appsecret=


### PR DESCRIPTION
?createDatabaseIfNotExist=true 는 해당 이름의 db가 없으면 생성
spring.jpa.hibernate.ddl-auto=update Entity에 해당 테이블이 없으면 생성 있으면 현재값 유지